### PR TITLE
Add build-base and libffi-dev so gem install sass works

### DIFF
--- a/sass-convert/Dockerfile
+++ b/sass-convert/Dockerfile
@@ -4,6 +4,7 @@ LABEL io.whalebrew.name 'sass-convert'
 LABEL io.whalebrew.config.working_dir '/workdir'
 WORKDIR /workdir
 
+RUN apk add --update build-base libffi-dev
 RUN gem install sass
 
 ENTRYPOINT ["sass-convert"]


### PR DESCRIPTION
Fixes #5. sass 3.5.0 introduced a dependency on listen which later turned to sass-listen.  This dependency had it's own dependencies, notably ffi, which failed to install with the base alpine image.  build-base and libffi-dev are both needed to install ffi properly, thus being able to install sass 3.5.

Note that the current Docker image of unibeautify/sass-convert works, but uses sass 3.4.24.  If it's preferable to not upgrade the image to sass 3.5, we can fix the build and tests by simply adding `--version 3.4.24`.