### PR TITLE
Build Uncrustify image into Unibeautify Dockerfile

### DIFF
--- a/uncrustify/Dockerfile
+++ b/uncrustify/Dockerfile
@@ -1,8 +1,28 @@
-FROM sonatest/docker-uncrustify
+FROM alpine:latest
 
 LABEL io.whalebrew.name 'uncrustify'
 LABEL io.whalebrew.config.working_dir '/workdir'
 WORKDIR /workdir
+
+ENV UNCRUSTIFY_VERSION 0.65
+
+RUN apk upgrade --update
+
+RUN apk add --no-cache make bash curl tar build-base cmake python3
+
+RUN curl -fSL "https://github.com/uncrustify/uncrustify/archive/uncrustify-$UNCRUSTIFY_VERSION.tar.gz" -o uncrustify.tar.gz  \
+	&& readonly NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || echo 1) \
+	&& echo "Using upto $NPROC threads" \
+	&& mkdir -p /usr/src/uncrustify \
+	&& tar -xf uncrustify.tar.gz -C /usr/src/uncrustify --strip-components=1 \
+	&& rm uncrustify.tar.gz* \
+	&& dir="$(mktemp -d)" \
+	&& cd "$dir" \
+	&& cmake /usr/src/uncrustify \
+	&& make -j$NPROC \
+	&& make install \
+	&& rm -rf "$dir" \
+	&& rm -rf /usr/src/uncrustify
 
 ENTRYPOINT ["uncrustify"]
 CMD ["--help"]


### PR DESCRIPTION
This commit builds the Uncrustify image from scratch using alpine and git clone, instead of relying on a now deleted docker image.  It runs fine, however I did notice a warning during the build:

```
CMake Warning at CMakeLists.txt:138 (message):
  scripts/make_version.py exited with code 64: Unknown version control system
  in '/usr/src/uncrustify'.

  As a fallback, version 'Uncrustify-0.65_f' will be used.
```

Something to keep an eye on.

Fixes #9 