### PR TITLE
Build phpcbf into Unibeautify image directly

### DIFF
--- a/phpcbf/Dockerfile
+++ b/phpcbf/Dockerfile
@@ -1,8 +1,10 @@
-FROM texthtml/phpcs
+FROM php:7.1-alpine
 
 LABEL io.whalebrew.name 'phpcbf'
 LABEL io.whalebrew.config.working_dir '/workdir'
 WORKDIR /workdir
+
+RUN pear install PHP_CodeSniffer
 
 ENTRYPOINT ["phpcbf"]
 CMD ["--help"]


### PR DESCRIPTION
This uses the official PHP Docker image then install PHPCBF into it directly, versus relying on a third party image for PHPCBF.