### PR TITLE
bump php-cs-fixer version, fix php 7.3 compatibility

### DIFF
--- a/php-cs-fixer/Dockerfile
+++ b/php-cs-fixer/Dockerfile
@@ -4,7 +4,7 @@ LABEL io.whalebrew.name 'php-cs-fixer'
 LABEL io.whalebrew.config.working_dir '/project'
 WORKDIR /project
 
-RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.13.1/php-cs-fixer.phar -O php-cs-fixer \
+RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.14.2/php-cs-fixer.phar -O php-cs-fixer \
   && chmod a+x php-cs-fixer \
   && mv php-cs-fixer /usr/local/bin/php-cs-fixer
 


### PR DESCRIPTION
Former php-cs-fixer (< 2.14) are not compatible with php 7.3 (see https://packagist.org/packages/fabpot/php-cs-fixer#v2.13.3), but the image is currently using php 7.3:

Using the image fails with:

`PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.2.*.`

This PR update php-cs-fixer to 2.14.2, hence fixing this image.