### PR TITLE
Feature: Build clang-format from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ e.g. `php-cs-fixer --version`
 e.g. `docker pull unibeautify/php-cs-fixer`
 2. Run the Docker image: `docker run -it -v "$(pwd)":/workdir -w /workdir unibeautify/BEAUTIFIER "--version"`  
 e.g. `docker run -it -v "$(pwd)":/workdir -w /workdir unibeautify/php-cs-fixer "--version"`
+
+Note: Some tools could change file ownership/permissions upon reformat and/or rewriting. Adding `--user "$(id -u):$(id -g)"` to your `docker run` command should prevent this.

--- a/clang-format/Dockerfile
+++ b/clang-format/Dockerfile
@@ -1,11 +1,32 @@
-FROM debian:sid-slim
+FROM alpine:latest as clang-format-build
 
-RUN apt-get update && \
-    apt-get install -y clang-format-6.0
+# Build dependencies
+RUN apk update && apk add git build-base ninja cmake python3
 
-# switch to uid/gid identical to host uid/gid (forks/users), if not doing this, files that
-# clang-format written will change user and group all to root.
-USER 1000:100
+# Pass `--build-arg LLVM_TAG=master` for latest llvm commit
+ARG LLVM_TAG
+ENV LLVM_TAG ${LLVM_TAG:-llvmorg-8.0.0}
 
-ENTRYPOINT ["clang-format-6.0"]
+# Download and setup
+WORKDIR /build
+RUN git clone --branch ${LLVM_TAG} --depth 1 https://github.com/llvm/llvm-project.git
+WORKDIR /build/llvm-project
+RUN mv clang llvm/tools
+RUN mv libcxx llvm/projects
+
+# Build
+WORKDIR llvm/build
+RUN cmake -GNinja -DLLVM_BUILD_STATIC=ON -DLLVM_ENABLE_LIBCXX=ON ..
+RUN ninja clang-format
+
+# Install
+FROM alpine:latest
+
+LABEL io.whalebrew.name 'clang-format'
+LABEL io.whalebrew.config.working_dir '/workdir'
+WORKDIR /workdir
+
+COPY --from=clang-format-build /build/llvm-project/llvm/build/bin/clang-format /usr/bin
+
+ENTRYPOINT ["clang-format"]
 CMD ["--help"]


### PR DESCRIPTION
This PR builds clang-format from source code and produces a smaller docker image than what is available now: from ~190MB to ~90MB.

I've also included the option to build the docker image with a specific git tag for LLVM releases. It defaults to the latest stable release (v8.0.0).

Also, instead of guessing the user's uid and gid, I've added documentation to the README for how to let docker use your current uid and gid during a `docker run`.