### PR TITLE
Fix black docker image builds

### DIFF
--- a/black/Dockerfile
+++ b/black/Dockerfile
@@ -1,18 +1,13 @@
-FROM python:3-alpine as black-build
-
-# we don't want gcc in the final image, so let's do a multi stage build
-RUN apk update && apk add --no-cache build-base
-RUN pip install --user --upgrade black
-
 FROM python:3-alpine
 
 LABEL io.whalebrew.name 'black'
 LABEL io.whalebrew.config.working_dir '/workdir'
 WORKDIR /workdir
 
-# copy only the installed files from black
-COPY --from=black-build /root/.local /root/.local
-ENV PATH=/root/.local/bin:$PATH
+# we don't want gcc in the final image, so remove it in one docker layer
+RUN apk add --no-cache build-base \
+    && pip install --no-cache-dir --upgrade black \
+    && apk del build-base
 
 ENTRYPOINT ["black"]
 CMD ["--help"]

--- a/black/Dockerfile
+++ b/black/Dockerfile
@@ -1,10 +1,18 @@
+FROM python:3-alpine as black-build
+
+# we don't want gcc in the final image, so let's do a multi stage build
+RUN apk update && apk add --no-cache build-base
+RUN pip install --user --upgrade black
+
 FROM python:3-alpine
 
 LABEL io.whalebrew.name 'black'
 LABEL io.whalebrew.config.working_dir '/workdir'
 WORKDIR /workdir
 
-RUN pip install --upgrade black
+# copy only the installed files from black
+COPY --from=black-build /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 
 ENTRYPOINT ["black"]
 CMD ["--help"]


### PR DESCRIPTION
The newest version of black broke our dockerfile because it requires gcc
to be installed. I've modified the black Dockerfile to a two-staged such
that the image size stays small.

Fixes #51